### PR TITLE
Introducing convenience methods for console logging.

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,4 +21,8 @@ en:
   doc_for_word: "Documentation for Word"
   copy_as_bookmarklet: "Copy as Bookmarklet to Clipboard"
   reformat_document: "Reformat Document"
+  console_debug: "Console Debug"
+  console_log: "Console Log"
+  console_warn: "Console Warn"
+  console_info: "Console Info"
   

--- a/snippets/snippets.rb
+++ b/snippets/snippets.rb
@@ -96,6 +96,26 @@ with_defaults :scope => "source.js" do
 }${4:,}"
   end
   
+  snippet t(:console_debug) do |s|
+    s.trigger = "cd"
+    s.expansion = "console.debug('${1:args}', ${0:// body...});"
+  end
+  
+  snippet t(:console_log) do |s|
+    s.trigger = "cl"
+    s.expansion = "console.log('${1:args}', ${0:// body...});"
+  end
+  
+  snippet t(:console_warn) do |s|
+    s.trigger = "cw"
+    s.expansion = "console.warn('${1:args}', ${0:// body...});"
+  end
+  
+  snippet t(:console_info) do |s|
+    s.trigger = "ci"
+    s.expansion = "console.info('${1:args}', ${0:// body...});"
+  end
+  
 # FIXME Not currently working due to unsupported TextMate functionality
   # snippet "Get Elements" do |s|
     # s.trigger = "get"


### PR DESCRIPTION
Convenience shortcuts for console debug, log, warn and info methods.

Just type cd in the JavaScript file and press Ctrl + Space.
cl for console.log
cw for console.warn
ci for console.info
